### PR TITLE
cambiar la forma de manejar los eventos

### DIFF
--- a/src/main/java/controladores/Controlador.java
+++ b/src/main/java/controladores/Controlador.java
@@ -23,7 +23,6 @@ import javafx.scene.control.TableView;
 import modelos.Envase;
 import modelos.ModeloTapa;
 import modelos.Tapa;
-import principal.ManejadorProperties;
 import utilidades.Exportar;
 import vistas.VistaListadoEnvases;
 
@@ -66,10 +65,10 @@ public class Controlador implements EventHandler<ActionEvent> {
         });
         stage.getIcons().add(new Image("/ies.png"));
         //Instancias de Vistas
-        vistaEnvase = new VistaEnvase();
-        vistaLogin = new VistaLogin();
-        vistaTapa = new VistaTapa();
-        vistaMenu = new VistaMenu();
+        vistaEnvase = new VistaEnvase(this);
+        vistaLogin = new VistaLogin(this);
+        vistaTapa = new VistaTapa(this);
+        vistaMenu = new VistaMenu(this);
         validador = new Validador();
         exportar = new Exportar();
         //Intancias de Modelos
@@ -78,35 +77,6 @@ public class Controlador implements EventHandler<ActionEvent> {
         modeloLogin = new ModeloLogin();
         modeloMovimientoEnvase = new ModeloMovimientoEnvase();
         modeloMovimientoTapa = new ModeloMovimientoTapa();
-        //Configuracion de las Vistas
-        vistaEnvase.config();
-        vistaLogin.config();
-        vistaTapa.config();
-        vistaMenu.config();
-        //Alta de Botones de las Vistas
-        vistaLogin.getBtnIngresar().setOnAction(this);
-        vistaLogin.getBtnIngresar().setDefaultButton(true); //Responde a ENTER el BtnIngresar+
-        vistaLogin.getBtnRegistrar().setOnAction(this);
-        vistaLogin.getBtnVolver().setOnAction(this);
-        vistaMenu.getBtnEnvase().setOnAction(this);
-        vistaMenu.getBtnTapas().setOnAction(this);
-        vistaMenu.getBtnListadoEnvases().setOnAction(this);
-        vistaMenu.getBtnListadoTapas().setOnAction(this);
-        vistaMenu.getBtnCerrarSesion().setOnAction(this);
-        vistaMenu.getBtnMovimientos().setOnAction(this);
-        vistaMenu.getBtnMovimientosTapa().setOnAction(this);
-        vistaEnvase.getBtnGuardarEv().setOnAction(this);
-        vistaEnvase.getBtnCancelar().setOnAction(this);
-        vistaEnvase.getBtnModificar().setOnAction(this);
-        vistaTapa.getBtnAceptar().setOnAction(this);
-        vistaTapa.getBtnCancelar().setOnAction(this);
-        vistaTapa.getBtnModificar().setOnAction(this);
-        vistaMenu.getBtnExportar().setOnAction(this);
-        vistaMenu.getBtnNuevoUsuario().setOnAction(this);
-        //Instanciamos la clase ManejadorProperties
-        ManejadorProperties propiedades = new ManejadorProperties(1);
-        stage.setTitle(propiedades.leerPropiedad("titulo"));
-        stage.setScene(vistaLogin.getScene());
         stage.setResizable(false);
         stage.show();
 
@@ -116,7 +86,14 @@ public class Controlador implements EventHandler<ActionEvent> {
     public void handle(ActionEvent event) {
         Button botonSeleccionado = (Button) event.getSource();
         String botonID = botonSeleccionado.getId();
-        switch (botonID) {
+        accionar(botonID);
+    }
+
+    public void accionar(String accion){
+        switch (accion) {
+            case "inicio":
+                mostrarLogin();
+                break;
             case "login_ingresar":
                 loginIngresar();
                 break;
@@ -196,6 +173,10 @@ public class Controlador implements EventHandler<ActionEvent> {
     }
 
     String letras = "Los campos deben ser completados sólo con letras";
+
+    private void mostrarLogin() {
+        stage.setScene(vistaLogin.getScene());
+    }
 
     public void movimientoEnvase(){
         vistaMovimiento = new VistaMovimiento(modeloEnvase.darTodosLosEnvases());

--- a/src/main/java/principal/Inicio.java
+++ b/src/main/java/principal/Inicio.java
@@ -13,6 +13,7 @@ public class Inicio extends Application {
     @Override
     public void start(Stage primaryStage) throws Exception {
         new Configurar();
-        new Controlador(primaryStage);
+        Controlador x = new Controlador(primaryStage);
+        x.accionar("inicio");
     }
 }

--- a/src/main/java/vistas/VistaEnvase.java
+++ b/src/main/java/vistas/VistaEnvase.java
@@ -1,5 +1,6 @@
 package vistas;
 
+import controladores.Controlador;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -27,7 +28,7 @@ public class VistaEnvase extends VistaPadre {
     private HBox edicion;
     private HBox bxButton;
 
-    public VistaEnvase() {
+    public VistaEnvase(Controlador c) {
         super();
         labelNom = new Label("Nombre");
         labelTipo = new Label("Tipo");
@@ -48,6 +49,14 @@ public class VistaEnvase extends VistaPadre {
         bxTextField = new VBox(5);
         edicion=new HBox(8);
         bxButton = new HBox(5);
+        bindEventController(c);
+        config();
+    }
+
+    public void bindEventController(Controlador c){
+        getBtnGuardarEv().setOnAction(c::handle);
+        getBtnCancelar().setOnAction(c::handle);
+        getBtnModificar().setOnAction(c::handle);
     }
     //Getters
     public TextField getTextId() { return textId; }

--- a/src/main/java/vistas/VistaLogin.java
+++ b/src/main/java/vistas/VistaLogin.java
@@ -1,6 +1,7 @@
 package vistas;
 
 
+import controladores.Controlador;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
@@ -25,12 +26,14 @@ public class VistaLogin extends VistaPadre {
     private String mensajeError;
 
     //Constructor
-    public VistaLogin() {
+    public VistaLogin(Controlador c) {
         super();
         implementarElementos();
         asignarIDs();
         escucharEnter();
         mostrarBotonesLogin();
+        bindEventController(c);
+        config();
     }
 
     //Metodos
@@ -56,6 +59,12 @@ public class VistaLogin extends VistaPadre {
         getBtnVolver().setId("volver_menu");
         getLabelUsuario().setId("user");
         getLabelContrasena().setId("pass");
+    }
+
+    public void bindEventController(Controlador controlador){
+        btnIngresar.setOnAction(controlador::handle);
+        btnRegistrar.setOnAction(controlador::handle);
+        btnVolver.setOnAction(controlador::handle);
     }
 
     public void config() {

--- a/src/main/java/vistas/VistaMenu.java
+++ b/src/main/java/vistas/VistaMenu.java
@@ -1,5 +1,6 @@
 package vistas;
 
+import controladores.Controlador;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -20,7 +21,7 @@ public class VistaMenu extends VistaPadre {
     private Button btnMovimientosTapa;
     private Label titulo;
 
-    public VistaMenu() {
+    public VistaMenu(Controlador c) {
         super();
         btnEnvase = new Button("Cargar Envase");
         btnEnvase.setMaxSize(200 , 200);
@@ -41,8 +42,21 @@ public class VistaMenu extends VistaPadre {
         btnMovimientosTapa = new Button("Manejo de Insumos - Tapas");
         btnMovimientosTapa.setMaxSize(200, 200);
         titulo = new Label("-----");
+        bindEventController(c);
+        config();
     }
 
+    public void bindEventController(Controlador c){
+        getBtnEnvase().setOnAction(c::handle);
+        getBtnTapas().setOnAction(c::handle);
+        getBtnListadoEnvases().setOnAction(c::handle);
+        getBtnListadoTapas().setOnAction(c::handle);
+        getBtnCerrarSesion().setOnAction(c::handle);
+        getBtnMovimientos().setOnAction(c::handle);
+        getBtnMovimientosTapa().setOnAction(c::handle);
+        getBtnExportar().setOnAction(c::handle);
+        getBtnNuevoUsuario().setOnAction(c::handle);
+    }
 
     public Button getBtnEnvase() {
         return btnEnvase;

--- a/src/main/java/vistas/VistaTapa.java
+++ b/src/main/java/vistas/VistaTapa.java
@@ -1,5 +1,6 @@
 package vistas;
 
+import controladores.Controlador;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -23,7 +24,7 @@ public class VistaTapa extends VistaPadre {
     HBox bxEdicion;
     HBox bxBotones;
 
-    public VistaTapa() {
+    public VistaTapa(Controlador c) {
         super();
         labelTipo = new Label("Nombre");
         labelDescripcion = new Label("Descripción");
@@ -40,6 +41,14 @@ public class VistaTapa extends VistaPadre {
         bxTextField = new VBox(5);
         bxEdicion = new HBox(8);
         bxBotones = new HBox(5);
+        bindEventController(c);
+        config();
+    }
+
+    public void bindEventController(Controlador c){
+        getBtnAceptar().setOnAction(c::handle);
+        getBtnCancelar().setOnAction(c::handle);
+        getBtnModificar().setOnAction(c::handle);
     }
 
     public TextField getTxTipo() {


### PR DESCRIPTION
Bastantes cambios en este commit:

En el controlador separe en un método aparte el switch para que se puedan ejecutar eventos sin la necesidad de tener que tener la interfaz funcionando.

En la clase main basado en el cambio anterior, cuando se instancia el controlador se debe llamar al método accionar y pasar como parámetro un string correspondiente a la acción que se quiera ejecutar.

Por último se introdujo un cambio en la forma en la que las vistas "bindean"/conocen de sus eventhandlers asociados. 
Ahora en cada vista se define un método que le pone a cada botón el controlador como argumento del método "setOnAction".

En el proximo pull request se procederá a aplicar el patrón command 🤞 